### PR TITLE
Add BookKeeper Metadata, like Pulsar (#138)

### DIFF
--- a/majordodo-core/src/main/java/majordodo/replication/LedgerMetadataUtils.java
+++ b/majordodo-core/src/main/java/majordodo/replication/LedgerMetadataUtils.java
@@ -38,12 +38,12 @@ public class LedgerMetadataUtils {
     private static final String CREATED_BY_METADATA = "broker-id";
 
     public static Map<String, byte[]> buildBrokerLedgerMetadata(String brokerId) {
-        byte[] createdByValue = brokerId == null ? null : brokerId.getBytes(StandardCharsets.UTF_8);
+        String createdByValue = brokerId == null ? "" : brokerId;
         
         return ImmutableMap.of(
             APPLICATION_METADATA, APPLICATION_METADATA_VALUE,
             COMPONENT_METADATA, COMPONENT_METADATA_VALUE,
-            CREATED_BY_METADATA, createdByValue
+            CREATED_BY_METADATA, createdByValue.getBytes(StandardCharsets.UTF_8)
         );
     }
 }

--- a/majordodo-core/src/main/java/majordodo/replication/LedgerMetadataUtils.java
+++ b/majordodo-core/src/main/java/majordodo/replication/LedgerMetadataUtils.java
@@ -1,0 +1,49 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package majordodo.replication;
+
+import com.google.common.collect.ImmutableMap;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ *
+ * @author dennis.mercuriali
+ */
+public class LedgerMetadataUtils {
+
+    private static final String APPLICATION_METADATA = "application";
+    private static final byte[] APPLICATION_METADATA_VALUE = "majordodo".getBytes(StandardCharsets.UTF_8);
+    
+    private static final String COMPONENT_METADATA = "component";
+    private static final byte[] COMPONENT_METADATA_VALUE = "broker".getBytes(StandardCharsets.UTF_8);
+    
+    private static final String CREATED_BY_METADATA = "broker-id";
+
+    public static Map<String, byte[]> buildBrokerLedgerMetadata(String brokerId) {
+        byte[] createdByValue = brokerId == null ? null : brokerId.getBytes(StandardCharsets.UTF_8);
+        
+        return ImmutableMap.of(
+            APPLICATION_METADATA, APPLICATION_METADATA_VALUE,
+            COMPONENT_METADATA, COMPONENT_METADATA_VALUE,
+            CREATED_BY_METADATA, createdByValue
+        );
+    }
+}

--- a/majordodo-core/src/test/java/majordodo/replication/ReplicatedCommitLogSimpleTest.java
+++ b/majordodo-core/src/test/java/majordodo/replication/ReplicatedCommitLogSimpleTest.java
@@ -19,15 +19,18 @@
  */
 package majordodo.replication;
 
+import java.nio.charset.StandardCharsets;
 import majordodo.task.BrokerStatusSnapshot;
 import majordodo.task.LogSequenceNumber;
 import majordodo.task.StatusEdit;
 import majordodo.task.Task;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
+import org.junit.Assert;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -41,6 +44,8 @@ import org.junit.rules.TemporaryFolder;
  * @author enrico.olivelli
  */
 public class ReplicatedCommitLogSimpleTest {
+    
+    private static final String BROKER_ID = "testBrokerId";
 
     @Rule
     public TemporaryFolder folderSnapshots = new TemporaryFolder();
@@ -70,6 +75,13 @@ public class ReplicatedCommitLogSimpleTest {
                 LogSequenceNumber logStatusEdit2 = log.logStatusEdit(edit2);
                 LogSequenceNumber logStatusEdit3 = log.logStatusEdit(edit3);
                 LogSequenceNumber logStatusEdit4 = log.logStatusEdit(edit4);
+                
+                zkServer.bookie.getBookie().getLedgerManagerFactory().newLedgerManager().readLedgerMetadata(log.getCurrentLedgerId(), (i, t) -> {
+                    Map<String, byte[]> customMeta = t.getCustomMetadata();
+                    Assert.assertEquals("majordodo", new String(customMeta.get("application"), StandardCharsets.UTF_8));
+                    Assert.assertEquals("broker", new String(customMeta.get("component"), StandardCharsets.UTF_8));
+                    Assert.assertEquals("", new String(customMeta.get("broker-id"), StandardCharsets.UTF_8));
+                });
             }
 
             try (ReplicatedCommitLog log = new ReplicatedCommitLog(zkServer.getAddress(), 40000, "/dodo", folderSnapshots.getRoot().toPath(), null, false);) {
@@ -95,7 +107,26 @@ public class ReplicatedCommitLogSimpleTest {
                 assertEquals(StatusEdit.TYPE_ASSIGN_TASK_TO_WORKER, edits.get(2).editType);
                 assertEquals("db1,db2", edits.get(2).resources);
                 assertEquals(StatusEdit.TYPE_TASK_STATUS_CHANGE, edits.get(3).editType);
-
+            }
+            
+            try (ReplicatedCommitLog log = new ReplicatedCommitLog(zkServer.getAddress(), 40000, "/dodo", 
+                folderSnapshots.getRoot().toPath(), null, false, Collections.emptyMap(), BROKER_ID);) {
+                
+                log.getClusterManager().start();
+                log.requestLeadership();
+                BrokerStatusSnapshot snapshot = log.loadBrokerStatusSnapshot();
+                log.recovery(snapshot.getActualLogSequenceNumber(), (a, b) -> {}, false);
+                log.startWriting();
+                
+                StatusEdit edit1 = StatusEdit.ADD_TASK(1, "mytask", "param1", "myuser", 0, 0, 0, null, 0, null, null);
+                log.logStatusEdit(edit1);
+                
+                zkServer.bookie.getBookie().getLedgerManagerFactory().newLedgerManager().readLedgerMetadata(log.getCurrentLedgerId(), (i, t) -> {
+                    Map<String, byte[]> customMeta = t.getCustomMetadata();
+                    Assert.assertEquals("majordodo", new String(customMeta.get("application"), StandardCharsets.UTF_8));
+                    Assert.assertEquals("broker", new String(customMeta.get("component"), StandardCharsets.UTF_8));
+                    Assert.assertEquals(BROKER_ID, new String(customMeta.get("broker-id"), StandardCharsets.UTF_8));
+                });
             }
 
         }

--- a/majordodo-embedded/src/main/java/majordodo/embedded/EmbeddedBroker.java
+++ b/majordodo-embedded/src/main/java/majordodo/embedded/EmbeddedBroker.java
@@ -185,7 +185,7 @@ public class EmbeddedBroker implements AutoCloseable {
                 }
                 ReplicatedCommitLog _statusChangesLog = new ReplicatedCommitLog(zkAdress, zkSessionTimeout, zkPath, _snapshotsDirectory,
                     BrokerHostData.formatHostdata(new BrokerHostData(host, port, Broker.VERSION(), ssl, additionalInfo)),
-                    zkSecure, additionalBookKeeperConfig
+                    zkSecure, additionalBookKeeperConfig, id
                 );
                 statusChangesLog = _statusChangesLog;
                 int ensemble = configuration.getIntProperty(EmbeddedBrokerConfiguration.KEY_BK_ENSEMBLE_SIZE, _statusChangesLog.getEnsemble());

--- a/majordodo-services/src/main/java/majordodo/broker/BrokerMain.java
+++ b/majordodo-services/src/main/java/majordodo/broker/BrokerMain.java
@@ -224,7 +224,7 @@ public class BrokerMain implements AutoCloseable {
                 }
                 ReplicatedCommitLog _log = new ReplicatedCommitLog(zkAddress, zkSessionTimeout, zkPath, Paths.get(snapdir),
                     BrokerHostData.formatHostdata(new BrokerHostData(host, port, Broker.VERSION(), ssl, additionalInfo)),
-                    zkSecure, additionalBookKeeperConfig
+                    zkSecure, additionalBookKeeperConfig, id
                 );
                 log = _log;
                 int ensemble = Integer.parseInt(configuration.getProperty("bookkeeper.ensemblesize", _log.getEnsemble() + ""));


### PR DESCRIPTION
New class LedgerMetadataUtils to build custom ledger metadata map.
'broker-id' metadata is passed at logger creation time and can't be changed (that logger will use the input broker-id for every ledger it creates).

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
