### PR TITLE
Make BookKeeper parameters be reconfigurable at runtime

### DIFF
--- a/majordodo-core/pom.xml
+++ b/majordodo-core/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.apache.bookkeeper</groupId>
             <artifactId>bookkeeper-server</artifactId>
-            <version>4.7.3</version>
+            <version>4.9.0</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.4</version>
+            <version>2.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -168,6 +168,6 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.0.v20161208</jetty.version>
+        <jetty.version>9.4.15.v20190215</jetty.version>
     </properties>
 </project>

--- a/majordodo-core/pom.xml
+++ b/majordodo-core/pom.xml
@@ -60,8 +60,14 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
                 <exclusion>
+                    <!-- netty 3 -->
                     <groupId>netty</groupId>
-                    <artifactId>io.netty</artifactId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <!-- netty 4 -->
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/majordodo-core/src/main/java/majordodo/replication/ReplicatedCommitLog.java
+++ b/majordodo-core/src/main/java/majordodo/replication/ReplicatedCommitLog.java
@@ -100,6 +100,7 @@ public class ReplicatedCommitLog extends StatusChangesLog {
     private long lastSequenceNumber = -1;
     private Path snapshotsDirectory;
     private LedgersInfo actualLedgersList;
+    // these are expected to be configurable at runtime from the EmbeddedBroker
     private volatile int ensembleSize = 1;
     private volatile int writeQuorumSize = 1;
     private volatile int ackQuorumSize = 1;

--- a/majordodo-core/src/main/java/majordodo/replication/ReplicatedCommitLog.java
+++ b/majordodo-core/src/main/java/majordodo/replication/ReplicatedCommitLog.java
@@ -100,9 +100,9 @@ public class ReplicatedCommitLog extends StatusChangesLog {
     private long lastSequenceNumber = -1;
     private Path snapshotsDirectory;
     private LedgersInfo actualLedgersList;
-    private int ensemble = 1;
-    private int writeQuorumSize = 1;
-    private int ackQuorumSize = 1;
+    private volatile int ensembleSize = 1;
+    private volatile int writeQuorumSize = 1;
+    private volatile int ackQuorumSize = 1;
     private long ledgersRetentionPeriod = 1000 * 60 * 60 * 24;
     private long maxLogicalLogFileSize = 1024 * 1024 * 256;
     private long writtenBytes = 0;
@@ -191,10 +191,10 @@ public class ReplicatedCommitLog extends StatusChangesLog {
 
         private CommitFileWriter() throws LogNotAvailableException {
             try {
-                this.out = bookKeeper.createLedger(ensemble, 
+                this.out = bookKeeper.createLedger(ensembleSize, 
                     writeQuorumSize, 
                     ackQuorumSize, 
-                    BookKeeper.DigestType.MAC, 
+                    BookKeeper.DigestType.CRC32C, 
                     sharedSecret.getBytes(StandardCharsets.UTF_8), 
                     LedgerMetadataUtils.buildBrokerLedgerMetadata(brokerId)
                 );
@@ -434,11 +434,11 @@ public class ReplicatedCommitLog extends StatusChangesLog {
     }
 
     public int getEnsemble() {
-        return ensemble;
+        return ensembleSize;
     }
 
     public void setEnsemble(int ensemble) {
-        this.ensemble = ensemble;
+        this.ensembleSize = ensemble;
     }
 
     public int getWriteQuorumSize() {

--- a/majordodo-embedded/src/main/java/majordodo/embedded/EmbeddedBroker.java
+++ b/majordodo-embedded/src/main/java/majordodo/embedded/EmbeddedBroker.java
@@ -251,4 +251,13 @@ public class EmbeddedBroker implements AutoCloseable {
         stop();
     }
 
+    /**
+     * Give access to the log, this way we will let 'embeeded' users to
+     * modify BookKeeper replication parameters dynamically
+     * @return 
+     */
+    public StatusChangesLog getStatusChangesLog() {
+        return statusChangesLog;
+    }
+
 }

--- a/majordodo-embedded/src/test/java/majordodo/embedded/BrokerEmbeddedClientTest.java
+++ b/majordodo-embedded/src/test/java/majordodo/embedded/BrokerEmbeddedClientTest.java
@@ -13,6 +13,7 @@ import majordodo.client.SubmitTaskResponse;
 import majordodo.client.TaskStatus;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import org.junit.Rule;
 import org.junit.Test;
@@ -31,6 +32,9 @@ public class BrokerEmbeddedClientTest {
 
         try (EmbeddedBroker main = new EmbeddedBroker(ee);) {
             main.start();
+            
+            // assert that we are able to access internal log
+            assertNotNull(main.getStatusChangesLog());
 
             try (EmbeddedClient client = new EmbeddedClient();
                     ClientConnection con = client.openConnection()) {

--- a/majordodo-net/pom.xml
+++ b/majordodo-net/pom.xml
@@ -20,7 +20,33 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
+            <artifactId>netty-buffer</artifactId>
+            <version>${libs.netty4}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+            <version>${libs.netty4}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>${libs.netty4}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+            <version>${libs.netty4}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-epoll</artifactId>
+            <version>${libs.netty4}</version>
+            <classifier>linux-x86_64</classifier>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-unix-common</artifactId>
             <version>${libs.netty4}</version>
         </dependency>
         <dependency>
@@ -65,8 +91,8 @@
     </dependencies>    
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <libs.netty4>4.1.22.Final</libs.netty4>
-        <libs.netty4.tcnative>2.0.7.Final</libs.netty4.tcnative>
+        <libs.netty4>4.1.34.Final</libs.netty4>
+        <libs.netty4.tcnative>2.0.23.Final</libs.netty4.tcnative>
         <libs.jackson>1.9.13</libs.jackson>
         <libs.zookeeper>3.5.3-beta</libs.zookeeper>
     </properties>

--- a/majordodo-services/pom.xml
+++ b/majordodo-services/pom.xml
@@ -10,7 +10,7 @@
     <name>Majordodo Services</name>
     <artifactId>majordodo-services</artifactId>
     <properties>
-        <jetty.version>9.4.0.v20161208</jetty.version>
+        <jetty.version>9.4.15.v20190215</jetty.version>
     </properties>
     <build>       
         <plugins>
@@ -35,7 +35,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.1.1</version>
                 <configuration>
                     <appendAssemblyId>false</appendAssemblyId>
                     <descriptors>

--- a/majordodo-services/src/main/assemble/zip-assembly.xml
+++ b/majordodo-services/src/main/assemble/zip-assembly.xml
@@ -34,8 +34,8 @@
             <useStrictFiltering>true</useStrictFiltering>
             <unpack>false</unpack>           
             <includes>
-                <include>*:jar</include>                                
-            </includes>                        
+                <include>*:jar:*</include>                                
+            </includes>
             <outputDirectory>lib</outputDirectory>
         </dependencySet>
         <dependencySet>


### PR DESCRIPTION
Let Embedded users access the internal log, this way it is possible to modify le configuration at runtime.
- This patch also updates BookKeeper to the latest and greatest version.
- Switch to CRC32C.
- Update Depdencies, like Jetty