### PR TITLE
update zookeeper to 3.5.5 in majordodo-client

### DIFF
--- a/majordodo-client/pom.xml
+++ b/majordodo-client/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.5.3-beta</version>
+            <version>3.5.5</version>
             <optional>true</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
Upgraded ZooKeeper dependency to v3.5.5 in Majordodo-client module

 - [X] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [X] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
