### PR TITLE
Upgrade Netty, Bookkeeper, ZooKeeper, Jetty and Jackson Mapper #161

### DIFF
--- a/majordodo-client/pom.xml
+++ b/majordodo-client/pom.xml
@@ -81,14 +81,14 @@
             <version>4.3.6</version>
         </dependency> 
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.13</version>            
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.10.3</version>
         </dependency>
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.5.5</version>
+            <version>3.5.7</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>

--- a/majordodo-client/src/main/java/majordodo/client/discovery/ZookeeperDiscoveryService.java
+++ b/majordodo-client/src/main/java/majordodo/client/discovery/ZookeeperDiscoveryService.java
@@ -19,8 +19,8 @@
  */
 package majordodo.client.discovery;
 
-import static org.apache.zookeeper.ServerAdminClient.stat;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URI;
@@ -35,7 +35,6 @@ import majordodo.client.BrokerDiscoveryService;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
-import org.codehaus.jackson.map.ObjectMapper;
 
 /**
  * Discevery service over zookeeper

--- a/majordodo-client/src/main/java/majordodo/client/http/HTTPClientConnection.java
+++ b/majordodo-client/src/main/java/majordodo/client/http/HTTPClientConnection.java
@@ -19,8 +19,8 @@
  */
 package majordodo.client.http;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import majordodo.client.ClientConnection;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -36,6 +36,7 @@ import java.util.stream.Collectors;
 import majordodo.client.BrokerAddress;
 import majordodo.client.BrokerDiscoveryService;
 import majordodo.client.BrokerStatus;
+import majordodo.client.ClientConnection;
 import majordodo.client.ClientException;
 import majordodo.client.CodePoolStatus;
 import majordodo.client.CreateCodePoolRequest;
@@ -58,7 +59,6 @@ import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.codehaus.jackson.map.ObjectMapper;
 
 @SuppressFBWarnings(value = "RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE",
         justification = "https://github.com/spotbugs/spotbugs/issues/756")

--- a/majordodo-core/pom.xml
+++ b/majordodo-core/pom.xml
@@ -45,9 +45,9 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.13</version>            
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.10.3</version>        
         </dependency>
         <dependency>
             <groupId>org.apache.bookkeeper</groupId>
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.5.6</version>
+            <version>3.5.7</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
@@ -153,6 +153,6 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jetty.version>9.4.18.v20190429</jetty.version>
+        <jetty.version>9.4.20.v20190813</jetty.version>
     </properties>
 </project>

--- a/majordodo-core/src/main/java/majordodo/clientfacade/HttpAPIImplementation.java
+++ b/majordodo-core/src/main/java/majordodo/clientfacade/HttpAPIImplementation.java
@@ -19,6 +19,7 @@
  */
 package majordodo.clientfacade;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -41,7 +42,6 @@ import javax.servlet.http.HttpServletResponse;
 import majordodo.network.jvm.JVMBrokersRegistry;
 import majordodo.task.Broker;
 import majordodo.task.Task;
-import org.codehaus.jackson.map.ObjectMapper;
 
 /**
  * Implementation of the HTTP API, both for embedded and for standalone installation

--- a/majordodo-core/src/main/java/majordodo/replication/LedgersInfo.java
+++ b/majordodo-core/src/main/java/majordodo/replication/LedgersInfo.java
@@ -19,13 +19,12 @@
  */
 package majordodo.replication;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.zookeeper.data.Stat;
-import org.codehaus.jackson.map.ObjectMapper;
 
 /**
  * Information on ledgers user by the broker

--- a/majordodo-core/src/main/java/majordodo/task/BrokerStatusSnapshot.java
+++ b/majordodo-core/src/main/java/majordodo/task/BrokerStatusSnapshot.java
@@ -19,6 +19,10 @@
  */
 package majordodo.task;
 
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -26,10 +30,6 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import majordodo.codepools.CodePool;
-import org.codehaus.jackson.JsonFactory;
-import org.codehaus.jackson.JsonGenerator;
-import org.codehaus.jackson.JsonParser;
-import org.codehaus.jackson.JsonToken;
 
 /**
  * Snapshot of the status of the broker

--- a/majordodo-core/src/main/java/majordodo/worker/WorkerHttpAPIImplementation.java
+++ b/majordodo-core/src/main/java/majordodo/worker/WorkerHttpAPIImplementation.java
@@ -19,6 +19,7 @@
  */
 package majordodo.worker;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -29,7 +30,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import majordodo.task.Broker;
-import org.codehaus.jackson.map.ObjectMapper;
 
 /**
  * Implementation of the HTTP API, both for embedded and for standalone installation

--- a/majordodo-net/pom.xml
+++ b/majordodo-net/pom.xml
@@ -56,8 +56,8 @@
             <scope>compile</scope>            
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
             <version>${libs.jackson}</version>            
         </dependency>
         <dependency>
@@ -91,9 +91,9 @@
     </dependencies>    
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <libs.netty4>4.1.34.Final</libs.netty4>
-        <libs.netty4.tcnative>2.0.23.Final</libs.netty4.tcnative>
-        <libs.jackson>1.9.13</libs.jackson>
-        <libs.zookeeper>3.5.5</libs.zookeeper>
+        <libs.netty4>4.1.48.Final</libs.netty4>
+        <libs.netty4.tcnative>2.0.30.Final</libs.netty4.tcnative>
+        <libs.jackson>2.10.3</libs.jackson>
+        <libs.zookeeper>3.5.7</libs.zookeeper>
     </properties>
 </project>

--- a/majordodo-net/src/main/java/majordodo/network/BrokerHostData.java
+++ b/majordodo-net/src/main/java/majordodo/network/BrokerHostData.java
@@ -19,13 +19,13 @@
  */
 package majordodo.network;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.HashMap;
 import java.util.Map;
-import org.codehaus.jackson.map.ObjectMapper;
 
 /**
  * Information about a broker

--- a/majordodo-services/pom.xml
+++ b/majordodo-services/pom.xml
@@ -10,7 +10,7 @@
     <name>Majordodo Services</name>
     <artifactId>majordodo-services</artifactId>
     <properties>
-        <jetty.version>9.4.18.v20190429</jetty.version>
+        <jetty.version>9.4.20.v20190813</jetty.version>
     </properties>
     <build>       
         <plugins>
@@ -94,9 +94,9 @@
             <version>${jetty.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
-            <version>1.9.13</version>            
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.10.3</version>           
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
## PR Description
Upgrades:
- Netty: 4.1.34.Final -> 4.1.48.Final
  - tcnative-boringssl-static: 2.0.23.Final -> 2.0.30.Final
- BookKeeper: Already on 4.10
- Zookeeper: 3.5.5/3.5.6 -> 3.5.7
- Jetty: 9.4.18.v20190429 -> 9.4.20.v20190813
- Jackson Mapper: 1.9.13 -> 2.10.3
  - org.codehaus.jackson#jackson-mapper-asl -> com.fasterxml.jackson.core#jackson-databind

## Formalities
Following this checklist to help us incorporate your 
contribution quickly and easily:

 - [x] Each commit in the pull request should have a meaningful subject line and body.
 - [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
 - [x] Rember to add the correct license header to new files.
 - [x] Run `mvn clean verify` to make sure basic checks pass. A more thorough check will 
       be performed on your pull request automatically.

To make clear that you license your contribution under 
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
