### PR TITLE
ZooKeeper update to 3.7.0

### DIFF
--- a/majordodo-client/pom.xml
+++ b/majordodo-client/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.5.9</version>
+            <version>3.6.3</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>

--- a/majordodo-client/pom.xml
+++ b/majordodo-client/pom.xml
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.6.3</version>
+            <version>3.7.0</version>
             <optional>true</optional>
             <exclusions>
                 <exclusion>

--- a/majordodo-core/pom.xml
+++ b/majordodo-core/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.6.3</version>
+            <version>3.7.0</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/majordodo-core/pom.xml
+++ b/majordodo-core/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.5.9</version>
+            <version>3.6.3</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>
@@ -114,6 +114,20 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <!-- needed for ZK server -->
+            <groupId>io.dropwizard.metrics</groupId>
+            <artifactId>metrics-core</artifactId>
+            <version>4.1.9</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <!-- needed for ZK server -->
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>1.1.7.6</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/majordodo-net/pom.xml
+++ b/majordodo-net/pom.xml
@@ -94,6 +94,6 @@
         <libs.netty4>4.1.72.Final</libs.netty4>
         <libs.netty4.tcnative>2.0.46.Final</libs.netty4.tcnative>
         <libs.jackson>2.10.5.1</libs.jackson>
-        <libs.zookeeper>3.5.9</libs.zookeeper>
+        <libs.zookeeper>3.6.3</libs.zookeeper>
     </properties>
 </project>

--- a/majordodo-net/pom.xml
+++ b/majordodo-net/pom.xml
@@ -94,6 +94,6 @@
         <libs.netty4>4.1.72.Final</libs.netty4>
         <libs.netty4.tcnative>2.0.46.Final</libs.netty4.tcnative>
         <libs.jackson>2.10.5.1</libs.jackson>
-        <libs.zookeeper>3.6.3</libs.zookeeper>
+        <libs.zookeeper>3.7.0</libs.zookeeper>
     </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13.1</version>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
ZK updated to 3.6.3.
Added some dependencies to -core to make it work (like snappy and metrics)...it seems that these dependencies are not needed for -client and -net (on other projects like blazingcache they are sometimes needed with the "scope" "test").

 - [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
